### PR TITLE
Use question mark token for optional props

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ class MyComponent extends React.Component {
 ```tsx
 type MyComponentProps = {
   prop1: string;
-  prop2: number | undefined;
+  prop2?: number;
 }
 
 type MyComponentState = {

--- a/test/react-js-make-props-and-state-transform/static-proptypes-many-props/output.tsx
+++ b/test/react-js-make-props-and-state-transform/static-proptypes-many-props/output.tsx
@@ -1,15 +1,15 @@
 import * as React from 'react';
 
 export default class MyComponent extends React.Component<{
-        any: any | undefined;
-        array: any[] | undefined;
-        bool: boolean | undefined;
-        func: ((...args: any[]) => any) | undefined;
-        number: number | undefined;
-        object: object | undefined;
-        string: string | undefined;
-        node: (number | string | JSX.Element) | undefined;
-        element: JSX.Element | undefined;
+        any?: any;
+        array?: any[];
+        bool?: boolean;
+        func?: (...args: any[]) => any;
+        number?: number;
+        object?: object;
+        string?: string;
+        node?: number | string | JSX.Element;
+        element?: JSX.Element;
         anyRequired: any;
         arrayRequired: any[];
         boolRequired: boolean;


### PR DESCRIPTION
Instead of 

```ts
type Props = {foo: number | undefined}
```

emits

```ts
type Props = {foo?: number}
```