### PR TITLE
Keep other static class members, such as defaultProps

### DIFF
--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -97,13 +97,10 @@ export function hasStaticModifier(classMember: ts.ClassElement) {
  */
 export function isPropTypesMember(classMember: ts.ClassElement, sourceFile: ts.SourceFile) {
     try {
-        const getFullTextName =
-            classMember.name !== undefined ? classMember.name.getFullText(sourceFile).trim() : undefined;
-        const escapedTextName =
-            classMember.name !== undefined && 'escapedText' in classMember.name
+        const name =
+            classMember.name !== undefined && classMember.name.kind === ts.SyntaxKind.Identifier
                 ? classMember.name.escapedText
-                : undefined;
-        const name = getFullTextName || escapedTextName;
+                : null;
         return name === 'propTypes';
     } catch (e) {
         return false;

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -97,7 +97,8 @@ export function hasStaticModifier(classMember: ts.ClassElement) {
  */
 export function isPropTypesMember(classMember: ts.ClassElement, sourceFile: ts.SourceFile) {
     try {
-        return classMember.name !== undefined && classMember.name.getFullText(sourceFile) !== 'propTypes';
+        const name = classMember.name !== undefined && classMember.name.getFullText(sourceFile).trim();
+        return name === 'propTypes';
     } catch (e) {
         return false;
     }

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -97,7 +97,13 @@ export function hasStaticModifier(classMember: ts.ClassElement) {
  */
 export function isPropTypesMember(classMember: ts.ClassElement, sourceFile: ts.SourceFile) {
     try {
-        const name = classMember.name !== undefined && classMember.name.getFullText(sourceFile).trim();
+        const getFullTextName =
+            classMember.name !== undefined ? classMember.name.getFullText(sourceFile).trim() : undefined;
+        const escapedTextName =
+            classMember.name !== undefined && 'escapedText' in classMember.name
+                ? classMember.name.escapedText
+                : undefined;
+        const name = getFullTextName || escapedTextName;
         return name === 'propTypes';
     } catch (e) {
         return false;

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -98,9 +98,7 @@ export function hasStaticModifier(classMember: ts.ClassElement) {
 export function isPropTypesMember(classMember: ts.ClassElement, sourceFile: ts.SourceFile) {
     try {
         const name =
-            classMember.name !== undefined && classMember.name.kind === ts.SyntaxKind.Identifier
-                ? classMember.name.escapedText
-                : null;
+            classMember.name !== undefined && ts.isIdentifier(classMember.name) ? classMember.name.escapedText : null;
         return name === 'propTypes';
     } catch (e) {
         return false;

--- a/test/react-remove-static-prop-types-member-transform/other-static-members/input.tsx
+++ b/test/react-remove-static-prop-types-member-transform/other-static-members/input.tsx
@@ -1,0 +1,8 @@
+class SomeComponent extends React.Component<{
+    foo: number;
+}, {
+    bar: string;
+}> {
+    static propTypes = { foo: React.PropTypes.string };
+    static defaultProps = { foo: 'bar' };
+}

--- a/test/react-remove-static-prop-types-member-transform/other-static-members/output.tsx
+++ b/test/react-remove-static-prop-types-member-transform/other-static-members/output.tsx
@@ -1,0 +1,10 @@
+class SomeComponent extends React.Component<
+    {
+        foo: number,
+    },
+    {
+        bar: string,
+    },
+> {
+    static defaultProps = { foo: 'bar' };
+}


### PR DESCRIPTION
I've been trying this out against our codebase, and I found that it was stripping out all static class members, not just propTypes.

Tracked down the issue to `isPropTypesMember` where `getFullText` returns a string surrounded by whitespace; so I've fixed that in https://github.com/lyft/react-javascript-to-typescript-transform/commit/95f6b0e8a2af0e9502724d5cc6de8a935d4bddea.

That makes it so that we check if `propTypes` === `propTypes`, instead of if the ` propTypes` !==  `propTypes`. And that makes it strip out propTypes, but keep all other static class members which is what I think we want!


Now here's the hacky part: 
that caused `end-to-end initial-state-and-proprypes` and `end-to-end initial-state-and-proprypes-and-set-state` to fail because `getFullText` returns empty in those cases (Going into the very nitty-gritty,  the `IdentifierType` in these cases has `pos: -1, end: -1`).

I'm using `escapedText` here as a fallback but this feels like a gigantic hack; have you run into this before, and do you know what might be the best way to fix it?