### PR TITLE
Safety/QOL fixes

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -46,6 +46,7 @@ program
             ignorePrettierErrors: !!program.ignorePrettierErrors,
         };
         const files = glob.sync(globPattern, {});
+        let errors = false;
         for (const file of files) {
             const filePath = path.resolve(file);
             const newPath = filePath.replace(/\.jsx?$/, '.tsx');
@@ -60,12 +61,16 @@ program
             } catch (error) {
                 console.warn(`Failed to convert ${file}`);
                 console.warn(error);
+                errors = true;
             }
             if (!program.keepTemporaryFiles) {
                 if (fs.existsSync(temporaryPath)) {
                     fs.unlinkSync(temporaryPath);
                 }
             }
+        }
+        if (errors) {
+            process.exit(1);
         }
     });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -69,6 +69,7 @@ program
         }
         let errors = false;
         for (const filePath of files) {
+            console.log(`Transforming ${filePath}...`);
             const newPath = filePath.replace(/\.jsx?$/, '.tsx');
             const temporaryPath = filePath.replace(/\.jsx?$/, `_js2ts_${+new Date()}.tsx`);
             try {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -26,6 +26,18 @@ program
         if (!globPattern) {
             throw new Error('You must provide a file name or glob pattern to transform');
         }
+        const prettierOptions: prettier.Options = {
+            arrowParens: program.arrowParens,
+            bracketSpacing: !program.noBracketSpacing,
+            jsxBracketSameLine: !!program.jsxBracketSameLine,
+            printWidth: parseInt(program.printWidth, 10),
+            proseWrap: program.proseWrap,
+            semi: !program.noSemi,
+            singleQuote: !!program.singleQuote,
+            tabWidth: parseInt(program.tabWidth, 10),
+            trailingComma: program.trailingComma,
+            useTabs: !!program.useTabs,
+        };
         const files = glob.sync(globPattern, {});
         for (const file of files) {
             const filePath = path.resolve(file);
@@ -33,18 +45,6 @@ program
 
             try {
                 fs.renameSync(filePath, newPath);
-                const prettierOptions: prettier.Options = {
-                    arrowParens: program.arrowParens,
-                    bracketSpacing: !program.noBracketSpacing,
-                    jsxBracketSameLine: !!program.jsxBracketSameLine,
-                    printWidth: parseInt(program.printWidth, 10),
-                    proseWrap: program.proseWrap,
-                    semi: !program.noSemi,
-                    singleQuote: !!program.singleQuote,
-                    tabWidth: parseInt(program.tabWidth, 10),
-                    trailingComma: program.trailingComma,
-                    useTabs: !!program.useTabs,
-                };
                 const result = run(newPath, prettierOptions);
                 fs.writeFileSync(newPath, result);
             } catch (error) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,6 +22,8 @@ program
     .option('--trailing-comma <none|es5|all>', 'Print trailing commas wherever possible when multi-line.', 'none')
     .option('--use-tabs', 'Indent with tabs instead of spaces.', false)
     .option('--ignore-prettier-errors', 'Ignore (but warn about) errors in Prettier', false)
+    .option('--keep-original-files', 'Keep original files', false)
+    .option('--keep-temporary-files', 'Keep temporary files', false)
     .usage('[options] <filename or glob>')
     .command('* <glob>')
     .action(globPattern => {
@@ -52,11 +54,17 @@ program
                 fs.copyFileSync(filePath, temporaryPath);
                 const result = run(temporaryPath, prettierOptions, compilationOptions);
                 fs.writeFileSync(newPath, result);
-                fs.unlinkSync(filePath);
-                fs.unlinkSync(temporaryPath);
+                if (!program.keepOriginalFiles) {
+                    fs.unlinkSync(filePath);
+                }
             } catch (error) {
                 console.warn(`Failed to convert ${file}`);
                 console.warn(error);
+            }
+            if (!program.keepTemporaryFiles) {
+                if (fs.existsSync(temporaryPath)) {
+                    fs.unlinkSync(temporaryPath);
+                }
             }
         }
     });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -42,11 +42,13 @@ program
         for (const file of files) {
             const filePath = path.resolve(file);
             const newPath = filePath.replace(/\.jsx?$/, '.tsx');
-
+            const temporaryPath = filePath.replace(/\.jsx?$/, `_js2ts_${+new Date()}.tsx`);
             try {
-                fs.renameSync(filePath, newPath);
-                const result = run(newPath, prettierOptions);
+                fs.copyFileSync(filePath, temporaryPath);
+                const result = run(temporaryPath, prettierOptions);
                 fs.writeFileSync(newPath, result);
+                fs.unlinkSync(filePath);
+                fs.unlinkSync(temporaryPath);
             } catch (error) {
                 console.warn(`Failed to convert ${file}`);
                 console.warn(error);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,6 +7,7 @@ import * as path from 'path';
 import * as prettier from 'prettier';
 
 import { run } from '.';
+import { CompilationOptions } from './compiler';
 
 program
     .version('1.0.0')
@@ -20,6 +21,7 @@ program
     .option('--tab-width <int>', 'Number of spaces per indentation level.', 2)
     .option('--trailing-comma <none|es5|all>', 'Print trailing commas wherever possible when multi-line.', 'none')
     .option('--use-tabs', 'Indent with tabs instead of spaces.', false)
+    .option('--ignore-prettier-errors', 'Ignore (but warn about) errors in Prettier', false)
     .usage('[options] <filename or glob>')
     .command('* <glob>')
     .action(globPattern => {
@@ -38,6 +40,9 @@ program
             trailingComma: program.trailingComma,
             useTabs: !!program.useTabs,
         };
+        const compilationOptions: CompilationOptions = {
+            ignorePrettierErrors: !!program.ignorePrettierErrors,
+        };
         const files = glob.sync(globPattern, {});
         for (const file of files) {
             const filePath = path.resolve(file);
@@ -45,7 +50,7 @@ program
             const temporaryPath = filePath.replace(/\.jsx?$/, `_js2ts_${+new Date()}.tsx`);
             try {
                 fs.copyFileSync(filePath, temporaryPath);
-                const result = run(temporaryPath, prettierOptions);
+                const result = run(temporaryPath, prettierOptions, compilationOptions);
                 fs.writeFileSync(newPath, result);
                 fs.unlinkSync(filePath);
                 fs.unlinkSync(temporaryPath);

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -8,6 +8,16 @@ import * as detectIndent from 'detect-indent';
 
 import { TransformFactoryFactory } from '.';
 
+export interface CompilationOptions {
+    ignorePrettierErrors: boolean;
+}
+
+const DEFAULT_COMPILATION_OPTIONS: CompilationOptions = {
+    ignorePrettierErrors: false,
+};
+
+export { DEFAULT_COMPILATION_OPTIONS };
+
 /**
  * Compile and return result TypeScript
  * @param filePath Path to file to compile
@@ -15,7 +25,8 @@ import { TransformFactoryFactory } from '.';
 export function compile(
     filePath: string,
     factoryFactories: TransformFactoryFactory[],
-    incomingPrettierOptions: prettier.Options = {}
+    incomingPrettierOptions: prettier.Options = {},
+    compilationOptions: CompilationOptions = DEFAULT_COMPILATION_OPTIONS,
 ) {
     const compilerOptions: ts.CompilerOptions = {
         target: ts.ScriptTarget.ES2017,
@@ -56,7 +67,16 @@ export function compile(
     const inputSource = fs.readFileSync(filePath, 'utf-8');
     const prettierOptions = getPrettierOptions(filePath, inputSource, incomingPrettierOptions);
 
-    return prettier.format(printed, prettierOptions);
+    try {
+        return prettier.format(printed, prettierOptions);
+    } catch (prettierError) {
+        if (compilationOptions.ignorePrettierErrors) {
+            console.warn(`Prettier failed for ${filePath} (ignorePrettierErrors is on):`);
+            console.warn(prettierError);
+            return printed;
+        }
+        throw prettierError;
+    }
 }
 
 /**

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -15,7 +15,7 @@ import { TransformFactoryFactory } from '.';
 export function compile(
     filePath: string,
     factoryFactories: TransformFactoryFactory[],
-    incomingPrettierOptions: prettier.Options = {},
+    incomingPrettierOptions: prettier.Options = {}
 ) {
     const compilerOptions: ts.CompilerOptions = {
         target: ts.ScriptTarget.ES2017,
@@ -56,7 +56,7 @@ export function compile(
     const inputSource = fs.readFileSync(filePath, 'utf-8');
     const prettierOptions = getPrettierOptions(filePath, inputSource, incomingPrettierOptions);
 
-    return prettier.format(printed, incomingPrettierOptions);
+    return prettier.format(printed, prettierOptions);
 }
 
 /**
@@ -76,7 +76,7 @@ export function getPrettierOptions(filePath: string, source: string, options: pr
     const semi = getUseOfSemi(source);
     const quotations = getQuotation(source);
 
-    _.defaults(options, {
+    _.defaults(Object.assign({}, options), {
         tabWidth: indentAmount,
         useTabs: indentType && indentType === 'tab',
         printWidth: sourceWidth,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import * as ts from 'typescript';
 import * as prettier from 'prettier';
 
-import { compile } from './compiler';
+import { compile, CompilationOptions, DEFAULT_COMPILATION_OPTIONS } from './compiler';
 import { reactJSMakePropsAndStateInterfaceTransformFactoryFactory } from './transforms/react-js-make-props-and-state-transform';
 import { reactRemovePropTypesAssignmentTransformFactoryFactory } from './transforms/react-remove-prop-types-assignment-transform';
 import { reactMovePropTypesToClassTransformFactoryFactory } from './transforms/react-move-prop-types-to-class-transform';
@@ -37,6 +37,10 @@ export type TransformFactoryFactory = (typeChecker: ts.TypeChecker) => ts.Transf
  * Run React JavaScript to TypeScript transform for file at `filePath`
  * @param filePath
  */
-export function run(filePath: string, prettierOptions: prettier.Options = {}): string {
-    return compile(filePath, allTransforms, prettierOptions);
+export function run(
+    filePath: string,
+    prettierOptions: prettier.Options = {},
+    compilationOptions: CompilationOptions = DEFAULT_COMPILATION_OPTIONS,
+): string {
+    return compile(filePath, allTransforms, prettierOptions, compilationOptions);
 }


### PR DESCRIPTION
This PR makes transformations a little safer and easier to script.

* Safety: a temporary .tsx file is first created as the transformation target, instead of wholesale renaming the original JS file to .tsx for transformation; if transformation succeeds, the target .tsx is written and the original and temporary files are deleted (unless the new `--keep-*-files` flags are set). (Before this, the original .js file was renamed but left untransformed if there were problems.)
* QOL: A new `--ignore-prettier-errors` option was added, to make it possible to use "almost working" TS files (see #38)
* QOL/scripting: The CLI now exits, as is customary, with error code 1 if there were any transformation problems.
* QOL/bugfix: Multiple files/glob parameters didn't work correctly before; only the first argument was parsed, and since glob expansion occurs at shell level, one would have had to invoke the command using `bin/... 'my/**.tsx'` (note the extra quotes). Multiple parameters (i.e. shell expansion) now works (but Node-level globs do too).
* QOL: A progress message was added to the otherwise very quiet CLI. :)

Thanks for the project – I've had lots of fun, even, converting codebases to TypeScript :)