### PR TITLE
[wip] Break down default export with variable assignment 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ node_modules
 dist
 .DS_Store
 coverage/
-.log
+*.log

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,7 +4,7 @@
         {
             "type": "node",
             "request": "launch",
-            "name": "Jest All",
+            "name": "Test All",
             "program": "${workspaceFolder}/node_modules/jest/bin/jest",
             "args": ["--runInBand"],
             "console": "integratedTerminal",
@@ -13,9 +13,9 @@
         {
             "type": "node",
             "request": "launch",
-            "name": "Jest A single case (edit config)",
+            "name": "Test A single case (edit 'args' config first)",
             "program": "${workspaceFolder}/node_modules/jest/bin/jest",
-            "args": ["-t", "remove-default-export-variable-assignment-transform basic"],
+            "args": ["-t", "end-to-end initial-state-and-proprypes-and-set-state"],
             "console": "integratedTerminal",
             "internalConsoleOptions": "neverOpen"
         }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,28 +2,22 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "args": [],
-            "cwd": "${workspaceRoot}",
-            "env": {
-                "NODE_ENV": "test"
-            },
-            "console": "internalConsole",
-            "name": "Run Tests",
-            "outFiles": ["${workspaceRoot}/dist"],
-            "preLaunchTask": "tsc",
-            "program": "${workspaceRoot}/node_modules/.bin/jest",
+            "type": "node",
             "request": "launch",
-            "runtimeArgs": [],
-            "runtimeExecutable": null,
-            "sourceMaps": true,
-            "stopOnEntry": false,
-            "type": "node"
+            "name": "Jest All",
+            "program": "${workspaceFolder}/node_modules/jest/bin/jest",
+            "args": ["--runInBand"],
+            "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Attach",
             "type": "node",
-            "request": "attach",
-            "port": 5858
+            "request": "launch",
+            "name": "Jest A single case (edit config)",
+            "program": "${workspaceFolder}/node_modules/jest/bin/jest",
+            "args": ["-t", "remove-default-export-variable-assignment-transform basic"],
+            "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen"
         }
     ]
 }

--- a/README.md
+++ b/README.md
@@ -114,3 +114,15 @@ Pass `-t` with transform name and case name space separated to `npm test`
 ```
 npm test -- -t "react-js-make-props-and-state-transform propless-stateless"
 ```
+
+#### Using Visual Studio Code to debug tests
+
+To run all test run "Test All" from debug panel.
+
+##### Run a single test
+
+Edit `.vscode/launch.json` to add the same argument you pass to jest for your specific test.
+
+##### Breakpoints work with test 🎉
+
+Throw a breakpoint anywhere in code to stop the test there and inspect issue.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 Transforms React code written in JavaScript to TypeScript.
 
 [**🖥 Download the VSCode Extension**](https://marketplace.visualstudio.com/items?itemName=mohsen1.react-javascript-to-typescript-transform-vscode)
+
 ## Features:
 
 * Proxies `PropTypes` to `React.Component` generic type and removes PropTypes

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,11 +27,11 @@ export const allTransforms = [
     reactMovePropTypesToClassTransformFactoryFactory,
     reactJSMakePropsAndStateInterfaceTransformFactoryFactory,
     reactStatelessFunctionMakePropsTransformFactoryFactory,
+    removeDefaultExportVariableAssignmentTransformFactoryFactory,
     collapseIntersectionInterfacesTransformFactoryFactory,
     reactRemovePropTypesAssignmentTransformFactoryFactory,
     reactRemoveStaticPropTypesMemberTransformFactoryFactory,
     reactRemovePropTypesImportTransformFactoryFactory,
-    removeDefaultExportVariableAssignmentTransformFactoryFactory,
 ];
 
 export type TransformFactoryFactory = (typeChecker: ts.TypeChecker) => ts.TransformerFactory<ts.SourceFile>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import { collapseIntersectionInterfacesTransformFactoryFactory } from './transfo
 import { reactRemoveStaticPropTypesMemberTransformFactoryFactory } from './transforms/react-remove-static-prop-types-member-transform';
 import { reactStatelessFunctionMakePropsTransformFactoryFactory } from './transforms/react-stateless-function-make-props-transform';
 import { reactRemovePropTypesImportTransformFactoryFactory } from './transforms/react-remove-prop-types-import';
+import { removeDefaultExportVariableAssignmentTransformFactoryFactory } from './transforms/remove-default-export-variable-assignment-transform';
 
 export {
     reactMovePropTypesToClassTransformFactoryFactory,
@@ -18,6 +19,7 @@ export {
     reactRemovePropTypesAssignmentTransformFactoryFactory,
     reactRemoveStaticPropTypesMemberTransformFactoryFactory,
     reactRemovePropTypesImportTransformFactoryFactory,
+    removeDefaultExportVariableAssignmentTransformFactoryFactory,
     compile,
 };
 
@@ -29,6 +31,7 @@ export const allTransforms = [
     reactRemovePropTypesAssignmentTransformFactoryFactory,
     reactRemoveStaticPropTypesMemberTransformFactoryFactory,
     reactRemovePropTypesImportTransformFactoryFactory,
+    removeDefaultExportVariableAssignmentTransformFactoryFactory,
 ];
 
 export type TransformFactoryFactory = (typeChecker: ts.TypeChecker) => ts.TransformerFactory<ts.SourceFile>;

--- a/src/transforms/remove-default-export-variable-assignment-transform.ts
+++ b/src/transforms/remove-default-export-variable-assignment-transform.ts
@@ -1,0 +1,67 @@
+import * as ts from 'typescript';
+import * as _ from 'lodash';
+
+import * as helpers from '../helpers';
+
+/**
+ * Remove default export variable assignment
+ *
+ * @example
+ * Before:
+ * export default const foo: string = 'str';
+ *
+ * After
+ * const foo: string = 'str';
+ * export default foo;
+ */
+export function removeDefaultExportVariableAssignmentTransformFactoryFactory(
+    typeChecker: ts.TypeChecker,
+): ts.TransformerFactory<ts.SourceFile> {
+    return function removeDefaultExportVariableAssignmentTransformFactory(context: ts.TransformationContext) {
+        return function removeDefaultExportVariableAssignmentTransform(sourceFile: ts.SourceFile) {
+            const visited = visitSourceFile(sourceFile, typeChecker);
+            ts.addEmitHelpers(visited, context.readEmitHelpers());
+            return visited;
+        };
+    };
+}
+
+function visitSourceFile(sourceFile: ts.SourceFile, typeChecker: ts.TypeChecker) {
+    let statements = _.toArray(sourceFile.statements);
+    const newStatements = [];
+
+    let index = 0;
+    while (index < statements.length) {
+        const statement = statements[index];
+        const nextStatement = statements[index + 1];
+        let statementText;
+        try {
+            statementText = statement.getText();
+        } catch {}
+
+        if (
+            nextStatement &&
+            ts.isExportAssignment(statement) &&
+            statementText === 'export default' &&
+            ts.isVariableStatement(nextStatement)
+        ) {
+            // push variable declaration
+            newStatements.push(nextStatement);
+
+            // push export default for variable declaration
+            const identifer = ts.createIdentifier(
+                nextStatement.declarationList.declarations[0] &&
+                    nextStatement.declarationList.declarations[0].name.getText(),
+            );
+            const defaultExport = ts.createExportDefault(identifer);
+            newStatements.push(defaultExport);
+
+            // skip next statement because we pushed nextStatement already
+            index++;
+        } else {
+            newStatements.push(statement);
+        }
+        index++;
+    }
+    return ts.updateSourceFileNode(sourceFile, newStatements);
+}

--- a/test/collapse-intersection-interfaces-transform/repeated/output.tsx
+++ b/test/collapse-intersection-interfaces-transform/repeated/output.tsx
@@ -1,12 +1,10 @@
 type A = {
     foo: string,
 };
-
 type B = {
     foo: string | number,
     bar: number,
 };
-
 type C = {
     foo: string | number,
     bar: number,

--- a/test/end-to-end/stateless-function-exported-default/input.tsx
+++ b/test/end-to-end/stateless-function-exported-default/input.tsx
@@ -1,0 +1,7 @@
+export default function Hello({ message }) {
+  return <div>hello {message}</div>
+}
+
+Hello.propTypes = {
+  message: React.PropTypes.string,
+}

--- a/test/end-to-end/stateless-function-exported-default/output.tsx
+++ b/test/end-to-end/stateless-function-exported-default/output.tsx
@@ -1,0 +1,8 @@
+type HelloProps = {
+    message?: string,
+};
+const Hello: React.SFC<HelloProps> = ({ message }) => {
+    return <div>hello {message}</div>;
+};
+
+export default Hello;

--- a/test/remove-default-export-variable-assignment-transform/basic/input.tsx
+++ b/test/remove-default-export-variable-assignment-transform/basic/input.tsx
@@ -1,0 +1,1 @@
+export default const foo: string = 'str';

--- a/test/remove-default-export-variable-assignment-transform/basic/output.tsx
+++ b/test/remove-default-export-variable-assignment-transform/basic/output.tsx
@@ -1,0 +1,2 @@
+const foo: string = 'str';
+export default foo;

--- a/test/remove-default-export-variable-assignment-transform/with-import/input.tsx
+++ b/test/remove-default-export-variable-assignment-transform/with-import/input.tsx
@@ -1,0 +1,3 @@
+import bar from 'bar';
+export default const foo: string = 'str';
+

--- a/test/remove-default-export-variable-assignment-transform/with-import/output.tsx
+++ b/test/remove-default-export-variable-assignment-transform/with-import/output.tsx
@@ -1,0 +1,3 @@
+import bar from 'bar';
+const foo: string = 'str';
+export default foo;

--- a/test/remove-default-export-variable-assignment-transform/with-other-exports/input.tsx
+++ b/test/remove-default-export-variable-assignment-transform/with-other-exports/input.tsx
@@ -1,0 +1,4 @@
+export const bar = 1;
+export default const foo: string = 'str';
+let baz = 1;
+export {baz};

--- a/test/remove-default-export-variable-assignment-transform/with-other-exports/output.tsx
+++ b/test/remove-default-export-variable-assignment-transform/with-other-exports/output.tsx
@@ -1,0 +1,5 @@
+export const bar = 1;
+const foo: string = 'str';
+export default foo;
+let baz = 1;
+export { baz };

--- a/test/remove-default-export-variable-assignment-transform/with-var-statement-after/input.tsx
+++ b/test/remove-default-export-variable-assignment-transform/with-var-statement-after/input.tsx
@@ -1,0 +1,2 @@
+export default const foo: string = 'str';
+var baz = 42;

--- a/test/remove-default-export-variable-assignment-transform/with-var-statement-after/output.tsx
+++ b/test/remove-default-export-variable-assignment-transform/with-var-statement-after/output.tsx
@@ -1,0 +1,3 @@
+const foo: string = 'str';
+export default foo;
+var baz = 42;

--- a/test/remove-default-export-variable-assignment-transform/with-var-statement-before/input.tsx
+++ b/test/remove-default-export-variable-assignment-transform/with-var-statement-before/input.tsx
@@ -1,0 +1,2 @@
+const bar = 1;
+export default const foo: string = 'str';

--- a/test/remove-default-export-variable-assignment-transform/with-var-statement-before/output.tsx
+++ b/test/remove-default-export-variable-assignment-transform/with-var-statement-before/output.tsx
@@ -1,0 +1,3 @@
+const bar = 1;
+const foo: string = 'str';
+export default foo;

--- a/test/transformers.test.ts
+++ b/test/transformers.test.ts
@@ -17,6 +17,7 @@ import {
     reactRemoveStaticPropTypesMemberTransformFactoryFactory,
     collapseIntersectionInterfacesTransformFactoryFactory,
     reactRemovePropTypesImportTransformFactoryFactory,
+    removeDefaultExportVariableAssignmentTransformFactoryFactory,
     allTransforms,
     compile,
     TransformFactoryFactory
@@ -32,6 +33,7 @@ const transformToFolderMap: [string, TransformFactoryFactory[]][] = [
     ['collapse-intersection-interfaces-transform', [collapseIntersectionInterfacesTransformFactoryFactory]],
     ['react-move-prop-types-to-class-transform', [reactMovePropTypesToClassTransformFactoryFactory]],
     ['react-remove-prop-types-import', [reactRemovePropTypesImportTransformFactoryFactory]],
+    ['remove-default-export-variable-assignment-transform', [removeDefaultExportVariableAssignmentTransformFactoryFactory]],
     ['end-to-end', allTransforms],
 ];
 


### PR DESCRIPTION
This change set introduces a new transform that breaks down an invalid code like this:


```ts
export default const MyComponent: React.RFC = () => null;
```

to

```ts
const MyComponent: React.RFC = () => null;
export default MyComponent
```

Fixes #38 