### PR TITLE
Fix `no parser` message from prettier

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -97,6 +97,7 @@ export function getPrettierOptions(filePath: string, source: string, options: pr
     const quotations = getQuotation(source);
 
     _.defaults(Object.assign({}, options), {
+      	parser: 'babel',
         tabWidth: indentAmount,
         useTabs: indentType && indentType === 'tab',
         printWidth: sourceWidth,


### PR DESCRIPTION
I get the following error when using the CLI:

```
No parser and no filepath given, using 'babel' the parser now but this will throw an error in the future. Please specify a parser or a filepath so one can be inferred.
```

This makes the parser choice explicit, see https://github.com/prettier/prettier/issues/4718.

Fixes #48